### PR TITLE
Fix bug with introspection

### DIFF
--- a/src/skeletonbase.cpp
+++ b/src/skeletonbase.cpp
@@ -230,9 +230,10 @@ DBusHandlerResult SkeletonBase::handle_request(DBusMessage* msg)
                "      <arg name=\"changed_properties\" type=\"a{sv}\"/>\n"
                "      <arg name=\"invalidated_properties\" type=\"as\"/>\n"
                "    </signal>\n"
-               "  </interface>\n"
-               "</node>\n";
+               "  </interface>\n";
          }
+
+         oss << "</node>\n";
 
          DBusMessage* reply = dbus_message_new_method_return(msg);
 


### PR DESCRIPTION
If this->properties_ is not set then the xml output will be missing the closing `</node>` tag and the introspection will fail.