### PR TITLE
Add missing include

### DIFF
--- a/include/simppl/stubbase.h
+++ b/include/simppl/stubbase.h
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <functional>
 #include <map>
+#include <string>
 
 #include <dbus/dbus.h>
 


### PR DESCRIPTION
When building with Clang against libc++, `stubbase.h` was missing a header file.