### PR TITLE
Better error handling

### DIFF
--- a/src/skeletonbase.cpp
+++ b/src/skeletonbase.cpp
@@ -361,7 +361,7 @@ DBusHandlerResult SkeletonBase::handle_request(DBusMessage* msg)
          pm = pm->next_;
       }
 
-      std::cerr << "method '" << method << "' unknown" << std::endl;
+      // std::cerr << "method '" << method << "' unknown" << std::endl;
    }
 
    return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;


### PR DESCRIPTION
The library used a mix of error handling techniques: exceptions,
asserts, and log messages.

Using asserts for error handling makes it impossible to catch and handle
errors. Instead a new `RuntimeError` class has been introduced for this
purpose.

Error messages written to stderr have been replaced with exceptions
where appropriate.