### PR TITLE
Fix a misleading indentation warning for gcc-7

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -27,7 +27,7 @@ char* create_objectpath(const char* iface, const char* role)
    {
       if (*p == '.')
          *p = '/';
-         ++p;
+      ++p;
    }
 
    return objectpath;


### PR DESCRIPTION
src/util.cpp: In function 'char* simppl::dbus::detail::create_objectpath(const char*, const char*)':
src/util.cpp:28:7: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
       if (*p == '.')
       ^~
src/util.cpp:30:10: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
          ++p;
          ^~
cc1plus: all warnings being treated as errors
CMakeFiles/simppl.dir/build.make:257: recipe for target 'CMakeFiles/simppl.dir/src/util.cpp.o' failed

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>