### PR TITLE
Remove \0 characters at end of interface names

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -77,7 +77,8 @@ std::string make_interface_name(const char* src, const char* end)
    assert(end > src);
 
    std::string name(end - src, '\0');
-   for (auto dst = name.begin(); src != end; ++dst, ++src) {
+   auto dst = name.begin();
+   for (; src != end; ++dst, ++src) {
       if (*src == ':') {
          *dst = '.';
          ++src;
@@ -85,6 +86,7 @@ std::string make_interface_name(const char* src, const char* end)
          *dst = *src;
       }
    }
+   name.resize(dst-name.begin());
    return name;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(unittests
    serialization.cpp
    multi_interface.cpp
    no_interface.cpp
+   utils.cpp
 )
 if(BOOST_FOUND)
    target_compile_definitions(unittests PRIVATE SIMPPL_HAVE_BOOST_FUSION=1)

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+
+#include "simppl/detail/util.h"
+
+namespace test
+{
+
+TEST(Utils, extract_interface)
+{
+   auto interface = simppl::dbus::detail::extract_interfaces(1,
+	"simppl::make_typelist<simppl::example::EchoService<0, simppl::dbus::SkeletonBase, simppl::dbus::ServerMethod, simppl::dbus::ServerSignal, simppl::dbus::ServerProperty, simppl::dbus::SkeletonBase> >");
+   ASSERT_EQ(1, interface.size());
+   EXPECT_EQ(interface[0], "simppl.example.EchoService");
+}
+
+}


### PR DESCRIPTION
I found a potential solution for issue #19. It has to do with the way, interface names are extracted from the mangled interface list.