### PR TITLE
Fix gcc 13 Compiler Errors

### DIFF
--- a/include/simppl/any.h
+++ b/include/simppl/any.h
@@ -3,7 +3,11 @@
 
 
 #include <any>
+#include <cassert>
+#include <cstring>
+#include <memory>
 #include <sstream>
+#include <variant>
 
 #include <dbus/dbus.h>
 

--- a/include/simppl/serverside.h
+++ b/include/simppl/serverside.h
@@ -278,9 +278,6 @@ struct BaseProperty : ServerPropertyBase
    {
        auto that = ((BaseProperty*)obj);
 
-       // missing initialization?
-       assert(!that->t_.empty());
-
        detail::PropertyCodec<DataT>::encode(*iter, std::get_if<cb_type>(&that->t_) ? (std::get<cb_type>(that->t_))() : std::get<DataT>(that->t_));
    }
 


### PR DESCRIPTION
This PR fixes issues occurring when compiling with gcc 13.
* Added missing includes.
* Removed assert against empty variant since an empty `std::variant` is not ill-formed as of [definition](https://en.cppreference.com/w/cpp/utility/variant).