### PR TITLE
Update gtest to v1.13.0

### DIFF
--- a/cmake/GoogleTest-CMakeLists.txt.in
+++ b/cmake/GoogleTest-CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.8.1
+  GIT_TAG           v1.13.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
This PR updates `gtest` to `v1.13.0` to fix gcc 13 compiler errors.