### PR TITLE
Using Properly Sized Types When Ever Possible

### DIFF
--- a/include/simppl/detail/inifile.h
+++ b/include/simppl/detail/inifile.h
@@ -3,6 +3,8 @@
 
 #include <limits>
 #include <type_traits>
+#include <cstdint>
+#include <cstdlib>
 
 #include "simppl/tribool.h"
 
@@ -206,7 +208,7 @@ struct Converter<char*>
 
 // TODO maybe we could use int for all smaller datatypes, but that's an optimization only
 static
-long long convert(const char* ptr, bool& success)
+int64_t convert(const char* ptr, bool& success)
 {
    int base = 10;
 
@@ -219,7 +221,7 @@ long long convert(const char* ptr, bool& success)
    }
 
    char* end;
-   long long rc = strtoll(ptr, &end, base);
+   int64_t rc = static_cast<int64_t>(std::strtoll(ptr, &end, base));
    success = (*end == '\0');
 
    return rc;
@@ -232,8 +234,8 @@ struct IntConverterBase
    static inline
    T eval(const char* ptr, bool& success)
    {
-      long long rc = convert(ptr, success);
-      success &= (rc >= (long long)std::numeric_limits<T>::min() && rc <= (long long)std::numeric_limits<T>::max());
+      int64_t rc = convert(ptr, success);
+      success &= (rc >= static_cast<int64_t>(std::numeric_limits<T>::min()) && rc <= static_cast<int64_t>(std::numeric_limits<T>::max()));
       return rc;
    }
 };

--- a/include/simppl/pod.h
+++ b/include/simppl/pod.h
@@ -1,6 +1,7 @@
 #ifndef SIMPPL_DBUS_POD_H
 #define SIMPPL_DBUS_POD_H
 
+#include <dbus/dbus-protocol.h>
 #ifndef SIMPPL_SERIALIZATION_H
 #   error "Do not include this file manually. Use serialization.h instead."
 #endif
@@ -20,19 +21,14 @@ namespace detail
 template<typename T>
 struct typecode_switch;
 
-template<> struct typecode_switch<char>               { enum { value = DBUS_TYPE_BYTE    }; };
 template<> struct typecode_switch<uint8_t>            { enum { value = DBUS_TYPE_BYTE    }; };
 template<> struct typecode_switch<uint16_t>           { enum { value = DBUS_TYPE_UINT16  }; };
 template<> struct typecode_switch<uint32_t>           { enum { value = DBUS_TYPE_UINT32  }; };
-//template<> struct dbus_type_code<uint64_t> { enum { value = DBUS_TYPE_UINT64  }; };
-template<> struct typecode_switch<unsigned long>      { enum { value = DBUS_TYPE_UINT32  }; };
-template<> struct typecode_switch<unsigned long long> { enum { value = DBUS_TYPE_UINT64  }; };
+template<> struct typecode_switch<uint64_t>           { enum { value = DBUS_TYPE_UINT64  }; };
 template<> struct typecode_switch<int8_t>             { enum { value = DBUS_TYPE_BYTE    }; };
 template<> struct typecode_switch<int16_t>            { enum { value = DBUS_TYPE_INT16   }; };
 template<> struct typecode_switch<int32_t>            { enum { value = DBUS_TYPE_INT32   }; };
-//template<> struct dbus_type_code<int64_t>  { enum { value = DBUS_TYPE_INT64   }; };
-template<> struct typecode_switch<long>               { enum { value = DBUS_TYPE_INT32   }; };
-template<> struct typecode_switch<long long>          { enum { value = DBUS_TYPE_INT64   }; };
+template<> struct typecode_switch<int64_t>            { enum { value = DBUS_TYPE_INT64   }; };
 template<> struct typecode_switch<double>             { enum { value = DBUS_TYPE_DOUBLE  }; };
 
 

--- a/include/simppl/serialization.h
+++ b/include/simppl/serialization.h
@@ -2,6 +2,7 @@
 #define SIMPPL_SERIALIZATION_H
 
 
+#include <cstdint>
 #include <sstream>
 
 #include <dbus/dbus.h>
@@ -40,17 +41,14 @@ template<typename T>
 struct isPod
 {
    typedef make_typelist<
-      char,
-      signed char,
-      unsigned char,
-      short,
-      unsigned short,
-      int,
-      unsigned int,
-      long,
-      unsigned long,
-      long long,
-      unsigned long long,
+      int8_t,
+      uint8_t,
+      int16_t,
+      uint16_t,
+      int32_t,
+      uint32_t,
+      int64_t,
+      uint64_t,
       float,
       double>::type pod_types;
 


### PR DESCRIPTION
Based on the dbus documentation ([ref0]) we get concrete requirements of how large specific types have to be. Example: t -> Unsigned 64-bit integer
Before we were using `unsigned long long` which by definition is **at least** 64 bit. So on some systems this type could be 72 bits if the implementation sees need for it ([ref1]).

[ref0]: https://dbus.freedesktop.org/doc/dbus-specification.html

[ref1]: https://stackoverflow.com/questions/5836329/how-many-bytes-is-unsigned-long-long