### PR TITLE
Make static library build possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ find_package(DBus REQUIRED)
 find_package(Boost)
 
 
-add_library(simppl SHARED
+add_library(simppl
     src/dispatcher.cpp
     src/error.cpp
     src/serverresponseholder.cpp


### PR DESCRIPTION
This change gives the library user an ability to decide whether to build static or shared library, using `BUILD_SHARED_LIBS` variable, see [corresponding CMake documentation](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html).