### PR TITLE
Missing file include removed + find_dependency include added

### DIFF
--- a/cmake/SimpplConfig.cmake.in
+++ b/cmake/SimpplConfig.cmake.in
@@ -2,7 +2,7 @@
 
 # Same syntax as find_package
 include(CMakeFindDependencyMacro)
-find_dependency(DBUS REQUIRED)
+find_dependency(DBUS REQUIRED) 
 
 check_required_components(Simppl)
 

--- a/cmake/SimpplConfig.cmake.in
+++ b/cmake/SimpplConfig.cmake.in
@@ -8,6 +8,4 @@ check_required_components(Simppl)
 if(NOT TARGET Simppl::simppl)
     # Provide path for scripts
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-
-    include(${CMAKE_CURRENT_LIST_DIR}/Catch2Targets.cmake)
 endif()

--- a/cmake/SimpplConfig.cmake.in
+++ b/cmake/SimpplConfig.cmake.in
@@ -1,6 +1,7 @@
 @PACKAGE_INIT@
 
 # Same syntax as find_package
+include(CMakeFindDependencyMacro)
 find_dependency(DBUS REQUIRED)
 
 check_required_components(Simppl)


### PR DESCRIPTION
When installing the library via `cmake --install`, using `find_package(Simppl)` will fail:

1) Because cmake files of the lib try to include `Catch2Targets.cmake`, which does not exist;
2) Because cmake files of the lib lack `include(CMakeFindDependencyMacro)` to use `find_dependency`.

To fix the issue, i removed the line with an import, and added an include.