### PR TITLE
Removed misleading colon in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Setup the eventloop and the server is finished:
    ```c++
    int main()
    {
-      simppl::dbus::Dispatcher disp("bus::session");
+      simppl::dbus::Dispatcher disp("bus:session");
       MyEcho instance(disp);
 
       disp.run();


### PR DESCRIPTION
Fixed a typo "bus::session" to "bus:session". Library fails to create a dispatcher with original variant.