### PR TITLE
Fixed MyEcho constructor in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ But there is still no response yet. Let's send a response back to the client:
 ```c++
    class MyEcho : simppl::dbus::Skeleton<EchoService>
    {
-      MyEcho()
-       : simppl::dbus::Skeleton<EchoService>("myEcho")
+      MyEcho(simppl::dbus::Dispatcher& disp)
+       : simppl::dbus::Skeleton<EchoService>(disp, "myEcho")
       {
          echo >> [this](const std::string& echo_string)
          {


### PR DESCRIPTION
Third example of `class MyEcho` does not have dispatcher ref argument in constructor. `Skeleton` can only be constructed with dispatcher ref.

Fixed this error. 

Here is the screenshot of how it was before fixing:
![image](https://github.com/user-attachments/assets/24fb1ec9-114e-4452-9eb9-9f73ce393aed)
