### PR TITLE
fix: build error with gcc-15

### DIFF
--- a/include/simppl/pendingcall.h
+++ b/include/simppl/pendingcall.h
@@ -1,7 +1,7 @@
 #ifndef SIMPPL_PENDINGCALL_H
 #define SIMPPL_PENDINGCALL_H
 
-
+#include <cstdint>
 #include "simppl/types.h"
 
 namespace simppl


### PR DESCRIPTION
:Release Notes:
Add missing #include.

:Detailed Notes:
Fixes:

http://gecko.lge.com:8000/Errors/Details/1139834

FAILED: CMakeFiles/simppl.dir/src/pendingcall.cpp.o TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/recipe-sysroot-native/usr/bin/aarch64-webos-linux/aarch64-webos-linux-g++ --sysroot=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/recipe-sysroot -DSIMPPL_HAVE_INTROSPECTION=1 -DSIMPPL_HAVE_OBJECTMANAGER=1 -Dsimppl_EXPORTS -ITOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git/simppl -ITOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/recipe-sysroot/usr/include/dbus-1.0 -ITOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/recipe-sysroot/usr/lib/dbus-1.0/include -ITOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git/include -mbranch-protection=standard -fstack-protector-all  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Werror=return-type -funwind-tables  --sysroot=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/recipe-sysroot  -O2 -g -fcanon-prefix-map  -fmacro-prefix-map=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git=/usr/src/debug/simppl/20250302  -fdebug-prefix-map=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git=/usr/src/debug/simppl/20250302  -fmacro-prefix-map=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/build=/usr/src/debug/simppl/20250302  -fdebug-prefix-map=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/build=/usr/src/debug/simppl/20250302  -fdebug-prefix-map=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/recipe-sysroot=  -fmacro-prefix-map=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/recipe-sysroot=  -fdebug-prefix-map=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/recipe-sysroot-native=  -fmacro-prefix-map=TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/recipe-sysroot-native=  -pipe -fvisibility-inlines-hidden -DNDEBUG -std=gnu++17 -fPIC -Werror -Wall -Wno-error=deprecated-declarations -MD -MT CMakeFiles/simppl.dir/src/pendingcall.cpp.o -MF CMakeFiles/simppl.dir/src/pendingcall.cpp.o.d -o CMakeFiles/simppl.dir/src/pendingcall.cpp.o -c TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git/src/pendingcall.cpp In file included from TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git/src/pendingcall.cpp:1: TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git/include/simppl/pendingcall.h:16:25: error: expected ')' before 'serial'
   16 |     PendingCall(uint32_t serial, DBusPendingCall* p);
      |                ~        ^~~~~~~
      |                         )
TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git/include/simppl/pendingcall.h:26:5: error: 'uint32_t' does not name a type
   26 |     uint32_t serial() const;
      |     ^~~~~~~~
TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git/include/simppl/pendingcall.h:6:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
    5 | #include "simppl/types.h"
  +++ |+#include <cstdint>
    6 |
TOPDIR/BUILD/work/qcs8550_aihub-webos-linux/simppl/20250302/git/include/simppl/pendingcall.h:37:5: error: 'uint32_t' does not name a type
   37 |     uint32_t serial_;
      |     ^~~~~~~~
...

:Testing Performed:
Only build tested.

:QA Notes:
No change to image.

:Issues Addressed:
[WRR-5443] Create GPVB with Yocto 5.2 Walnascar